### PR TITLE
replace "array" with less ambiguous "phparray"

### DIFF
--- a/AdminerDumpArray.php
+++ b/AdminerDumpArray.php
@@ -11,18 +11,18 @@ class AdminerDumpArray {
 	protected $database = false;
 
 	function dumpFormat() {
-		return array('array' => 'PHP Array');
+		return array('phparray' => 'PHP Array');
 	}
 
 	function dumpTable($table, $style, $is_view = false) {
-		if ($_POST["format"] == "array") {
+		if ($_POST["format"] == "phparray") {
 			return true;
 		}
 	}
 
 	function dumpData($table, $style, $query) {
 
-		if ($_POST["format"] == "array") {
+		if ($_POST["format"] == "phparray") {
 			$connection = connection();
 			$result = $connection->query($query, 1);
 			$table = $table ?: 'data';
@@ -46,7 +46,7 @@ class AdminerDumpArray {
 	}
 
 	function dumpHeaders($identifier, $multi_table = false) {
-		if ($_POST["format"] == "array") {
+		if ($_POST["format"] == "phparray") {
 			$identifier = $identifier ?: 'data';
 			header("Content-Type: ".($_POST['output'] == 'text' ? 'text/plain' : 'application/x-php')."; charset=utf-8");
 			return "php";


### PR DESCRIPTION
imagine if someone else comes along and makes a "json array" export plugin also using the identifier "array" - then the 2 plugins would collide 

should be safer to use the identifier "phparray"

(on an unrelated note, kudos for making a memory-optimized streaming implementation, i imagine most wouldn't have bothered, and would just memory-error on large exports with 1 huge array and a single var_export() call!)